### PR TITLE
[FIX-834] Fix missing-character bug + maintenance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,8 @@
 ################################################################################
 
 /Swifter.FSharpTest/obj
+*/bin/Debug/*
+*/obj/*
+*.dtbcache*
+*.suo
+.vs/Swifter/*/TestStore/*

--- a/Swifter.Core/Swifter.Core.csproj
+++ b/Swifter.Core/Swifter.Core.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net20;net35;net40;net45;net47;netstandard2.0;netcoreapp2.0;netcoreapp2.1;netcoreapp3.0</TargetFrameworks>
+    <TargetFrameworks>net20;net35;net40;net45;net47;net472;netstandard2.0;netcoreapp2.0;netcoreapp2.1;netcoreapp3.0</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <Version>1.5.0</Version>
     <Authors>Dogwei</Authors>
@@ -50,6 +50,10 @@
   <ItemGroup Condition="'$(TargetFramework)' == 'net47'">
     <PackageReference Include="System.Numerics.Vectors" Version="4.5.0" />
   </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net472'">
+	<PackageReference Include="System.Numerics.Vectors" Version="4.5.0" />
+  </ItemGroup>
   
   <ItemGroup Condition="'$(TargetFramework)' == 'net40'">
     <PackageReference Include="System.ValueTuple" Version="4.5.0" />
@@ -69,6 +73,9 @@
   </PropertyGroup>
   <PropertyGroup Condition="'$(TargetFramework)' == 'net47'">
     <DefineConstants>Async;Buffers;Emit;Linq;Vector;FullParse;ThreadYield;</DefineConstants>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(TargetFramework)' == 'net472'">
+	<DefineConstants>Async;Buffers;Emit;Linq;Vector;FullParse;ThreadYield;</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <DefineConstants>Async;Buffers;Emit;Linq;Vector;FullParse;ThreadYield;</DefineConstants>

--- a/Swifter.Core/VersionDifferences/BinaryPrimitives.cs
+++ b/Swifter.Core/VersionDifferences/BinaryPrimitives.cs
@@ -1,4 +1,4 @@
-﻿#if NET20 || NET35 || NET40 || NET45 || NET47 || NETSTANDARD2_0 || NETCOREAPP2_0
+﻿#if NET20 || NET35 || NET40 || NET45 || NET47 || NET472 || NETSTANDARD2_0 || NETCOREAPP2_0
 
 using Swifter;
 using System.Runtime.CompilerServices;

--- a/Swifter.Data/Swifter.Data.csproj
+++ b/Swifter.Data/Swifter.Data.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net20;net35;net40;net45;net47;netstandard2.0;netcoreapp2.0;netcoreapp2.1;netcoreapp3.0</TargetFrameworks>
+    <TargetFrameworks>net20;net35;net40;net45;net47;net472;netstandard2.0;netcoreapp2.0;netcoreapp2.1;netcoreapp3.0</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <Version>1.5.0</Version>
     <Authors>Dogwei</Authors>
@@ -37,6 +37,9 @@
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net47'">
     <Reference Include="System.Configuration" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'net472'">
+	<Reference Include="System.Configuration" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
@@ -83,6 +86,9 @@
     <DefineConstants>Emit;Linq;Dynamic;Dpf;</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition="'$(TargetFramework)' == 'net45'">
+    <DefineConstants>Async;Emit;Linq;Dynamic;Dpf;</DefineConstants>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(TargetFramework)' == 'net47'">
     <DefineConstants>Async;Emit;Linq;Dynamic;Dpf;</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition="'$(TargetFramework)' == 'net47'">

--- a/Swifter.Json/JsonSerializer.cs
+++ b/Swifter.Json/JsonSerializer.cs
@@ -555,13 +555,13 @@ namespace Swifter.Json
 
                 --depth;
 
-                Expand(2);
-
                 if (tCurrent != current)
                 {
                     --current;
                 }
             }
+
+            Expand(2);
 
             AppendStructAfter();
 

--- a/Swifter.Json/Swifter.Json.csproj
+++ b/Swifter.Json/Swifter.Json.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net20;net35;net40;net45;net47;netstandard2.0;netcoreapp2.0;netcoreapp2.1;netcoreapp3.0</TargetFrameworks>
+    <TargetFrameworks>net20;net35;net40;net45;net47;net472;netstandard2.0;netcoreapp2.0;netcoreapp2.1;netcoreapp3.0</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <Version>1.5.0</Version>
     <Authors>Dogwei</Authors>
@@ -48,6 +48,9 @@
     <DefineConstants>Async;Dynamic;</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition="'$(TargetFramework)' == 'net47'">
+    <DefineConstants>Async;Dynamic;</DefineConstants>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(TargetFramework)' == 'net472'">
     <DefineConstants>Async;Dynamic;</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">

--- a/Swifter.MessagePack/Swifter.MessagePack.csproj
+++ b/Swifter.MessagePack/Swifter.MessagePack.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net20;net35;net40;net45;net47;netstandard2.0;netcoreapp2.0;netcoreapp2.1;netcoreapp3.0</TargetFrameworks>
+    <TargetFrameworks>net20;net35;net40;net45;net47;net472;netstandard2.0;netcoreapp2.0;netcoreapp2.1;netcoreapp3.0</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <Version>1.5.0</Version>
     <Authors>Dogwei</Authors>
@@ -48,6 +48,9 @@
     <DefineConstants>Async;Dynamic;</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition="'$(TargetFramework)' == 'net47'">
+    <DefineConstants>Async;Dynamic;</DefineConstants>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(TargetFramework)' == 'net472'">
     <DefineConstants>Async;Dynamic;</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">

--- a/Swifter.Test.NUnit/JsonTest.cs
+++ b/Swifter.Test.NUnit/JsonTest.cs
@@ -808,6 +808,26 @@ namespace Swifter.Test
             AreEqual(json, "{\"ABCDEFGHI\":[]}");
         }
 
+        [Test]
+        public void EmptyArrayComplexTypeTest()
+        {
+            var jsonFormatter = new JsonFormatter(JsonFormatterOptions.EmptyStringAsNull);
+
+            // We need to set the MinSize low so we can observe a specific bug.
+            var prop = typeof(HGlobalCache<char>).GetField("AbsolutelyMinSize", BindingFlags.Public | BindingFlags.Static);
+
+            prop.SetValue(null, 1);
+            HGlobalCache<char>.MinSize = 1;
+
+            var obj = new Dictionary<string, NestingObject[]>
+            {
+                ["ABCDEFGHI"] = new NestingObject[0]
+            };
+
+            var json = jsonFormatter.Serialize(obj);
+
+            AreEqual(json, "{\"ABCDEFGHI\":[]}");
+        }
 
         public class NestingObject
         {


### PR DESCRIPTION
Fix issue in JsonSerializer.cs that meant if the buffer needed resizing while writing an empty array, the most-recently-written character ('[') gets dropped from current, meaning you end up with invalid json. Fixed by moving the resize to after anything else in the method that does pointer arithmatic.

Also create a meaningful gitignore, and add support for .NET Framework 4.7.2